### PR TITLE
Fix auto-scroll on result loading

### DIFF
--- a/scripts/src/view/output.tsx
+++ b/scripts/src/view/output.tsx
@@ -300,6 +300,10 @@ module fugazi.view {
 		private onDoubleClick(event: React.MouseEvent<HTMLDivElement>) {
 			event.stopPropagation();
 			PsSingleton.blur(this.container);
+			var selection = window.getSelection();
+			if (selection) {
+				selection.removeAllRanges();
+			}
 		}
 
 		private success(value: any): void {

--- a/scripts/src/view/output.tsx
+++ b/scripts/src/view/output.tsx
@@ -169,7 +169,7 @@ module fugazi.view {
 								<i className="fa fa-square-o"></i>
 								{ (info as ExecutionOutputItemInfo).statement }
 							</div>
-							<ResultView result={ (info as ExecutionOutputItemInfo).result } onStyleChange={ this.onStyleChange.bind(this) } />
+							<ResultView result={ (info as ExecutionOutputItemInfo).result } onBeforeStyleChange={ this.onBeforeStyleChange.bind(this) } onStyleChange={ this.onStyleChange.bind(this) } />
 						</li>);
 					}
 				} else {
@@ -200,8 +200,11 @@ module fugazi.view {
 			PsSingleton.blur();
 		}
 
-		private onStyleChange(): void {
+		private onBeforeStyleChange(): void {
 			this.shouldScrollBottom = this.checkOverflow();
+		}
+
+		private onStyleChange(): void {
 			this.componentDidUpdate();
 		}
 
@@ -212,6 +215,7 @@ module fugazi.view {
 	}
 
 	interface ResultViewProperties extends ViewProperties {
+		onBeforeStyleChange: StyleChangeListener;
 		onStyleChange: StyleChangeListener;
 		result: components.commands.ExecutionResult;
 	}
@@ -239,6 +243,14 @@ module fugazi.view {
 		 */
 		public componentDidMount(): void {
 			this.props.result.then(this.success.bind(this)).catch(this.fail.bind(this));
+		}
+
+		public componentWillUpdate(): void {
+			this.props.onBeforeStyleChange();
+		}
+
+		public componentDidUpdate(): void {
+			this.props.onStyleChange();
 		}
 
 		/**


### PR DESCRIPTION
* When already scrolled to the bottom of output and a you execute a command it adds the result view and then scrolls to the bottom. When when the result actually successfully loads and re-renders it can become a larger view but does not scroll further accordingly. This fixes that
* Single click on result brings it to focus, double click removes focus. Browsers generally use double click for text selection. This is now disabled during a double click of a result. Unfortunately the React MouseEvent.preventDefault doesn't actually prevent this so I manually removed the text selection if there is one