### PR TITLE
input multiline support

### DIFF
--- a/scripts/src/app/input.parser.ts
+++ b/scripts/src/app/input.parser.ts
@@ -1,11 +1,11 @@
 import * as collections from "../core/types.collections";
 import * as inputModule from "./input";
 
-var input: Input,
+let input: Input,
 	stack: StateStack;
 
 export function parse(commandInput: string): inputModule.CommandExpression {
-	var state: ParserState<any>,
+	let state: ParserState<any>,
 		command: CommandState;
 
 	input = new Input(commandInput);
@@ -89,7 +89,7 @@ class Input {
 	}
 
 	use(startIndex: number = this.used): UsedInput {
-		var usedInput: UsedInput = {
+		const usedInput: UsedInput = {
 			value: this.substring(startIndex, this.cursor),
 			range: new inputModule.RangeImpl(startIndex, this.cursor)
 		};
@@ -162,8 +162,7 @@ class ParserState<T extends inputModule.Expression<any>> {
 	}
 }
 
-class AtomicState<T extends inputModule.Expression<any>> extends ParserState<T> {
-}
+class AtomicState<T extends inputModule.Expression<any>> extends ParserState<T> {}
 
 class WordState extends AtomicState<inputModule.Word> {
 	private static ILLEGAL_CHARACTERS: string[] = ": \" ' [ ( { ,".split(" ");
@@ -180,7 +179,7 @@ class WordState extends AtomicState<inputModule.Word> {
 	 * @override
 	 */
 	parse(): StateStatus {
-		var expressionState: inputModule.ExpressionState,
+		let expressionState: inputModule.ExpressionState,
 			used: UsedInput;
 
 		while (!this.parsingEnded()) {
@@ -227,7 +226,7 @@ class StringState extends AtomicState<inputModule.StringParameter> {
 	 * @override
 	 */
 	parse(): StateStatus {
-		var expressionState: inputModule.ExpressionState,
+		let expressionState: inputModule.ExpressionState,
 			used: UsedInput;
 
 		input.advance();
@@ -344,7 +343,7 @@ class CommandState extends CompoundState<inputModule.CommandExpression> {
 	}
 
 	private handleEnd(): void {
-		var expressionState: inputModule.ExpressionState,
+		let expressionState: inputModule.ExpressionState,
 			used: UsedInput;
 
 		this.status = StateStatus.Done;

--- a/scripts/src/app/input.parser.ts
+++ b/scripts/src/app/input.parser.ts
@@ -63,12 +63,12 @@ class Input {
 		return this.cursor >= this.value.length;
 	}
 
-	get space(): boolean {
-		return this.current === " ";
+	get whitespace(): boolean {
+		return this.current.test(/\s/);
 	}
 
-	skipSpaces(use: boolean = false): void {
-		while (this.space) {
+	skipWhitespace(use: boolean = false): void {
+		while (this.whitespace) {
 			this.cursor++;
 		}
 
@@ -134,7 +134,7 @@ enum StateStatus {
 	Error
 }
 
-class ParserState<T extends inputModule.Expression<any>> {
+class ParserState<T extends inputModule.Expression> {
 	protected start: number;
 	protected expression: T;
 	protected status: StateStatus;
@@ -158,11 +158,11 @@ class ParserState<T extends inputModule.Expression<any>> {
 	}
 
 	protected parsingEnded(): boolean {
-		return input.eof || input.space;
+		return input.eof || input.whitespace;
 	}
 }
 
-class AtomicState<T extends inputModule.Expression<any>> extends ParserState<T> {}
+class AtomicState<T extends inputModule.Expression> extends ParserState<T> {}
 
 class WordState extends AtomicState<inputModule.Word> {
 	private static ILLEGAL_CHARACTERS: string[] = ": \" ' [ ( { ,".split(" ");
@@ -175,9 +175,6 @@ class WordState extends AtomicState<inputModule.Word> {
 		this.endingCharacters = typeof endingCharacters === "string" ? endingCharacters.split(" ") : endingCharacters;
 	}
 
-	/**
-	 * @override
-	 */
 	parse(): StateStatus {
 		let expressionState: inputModule.ExpressionState,
 			used: UsedInput;
@@ -191,7 +188,7 @@ class WordState extends AtomicState<inputModule.Word> {
 			input.advance();
 		}
 
-		expressionState = input.space || this.endingCharacters.includes(input.current) ? inputModule.ExpressionState.Complete : inputModule.ExpressionState.Unknown;
+		expressionState = input.whitespace || this.endingCharacters.includes(input.current) ? inputModule.ExpressionState.Complete : inputModule.ExpressionState.Unknown;
 		used = input.use();
 
 		if (used.range.length == 0) {
@@ -204,9 +201,6 @@ class WordState extends AtomicState<inputModule.Word> {
 		return this.status;
 	}
 
-	/**
-	 * @override
-	 */
 	protected parsingEnded(): boolean {
 		return super.parsingEnded() || this.endingCharacters.includes(input.current);
 	}
@@ -222,9 +216,6 @@ class StringState extends AtomicState<inputModule.StringParameter> {
 		this.quoteChar = input.current;
 	}
 
-	/**
-	 * @override
-	 */
 	parse(): StateStatus {
 		let expressionState: inputModule.ExpressionState,
 			used: UsedInput;
@@ -254,15 +245,12 @@ class StringState extends AtomicState<inputModule.StringParameter> {
 		return this.status;
 	}
 
-	/**
-	 * @override
-	 */
 	protected parsingEnded(): boolean {
 		return input.eof || (input.current === this.quoteChar && !this.escaped);
 	}
 }
 
-class CompoundState<T extends inputModule.Expression<any>> extends ParserState<T> {
+class CompoundState<T extends inputModule.Expression> extends ParserState<T> {
 	protected innerState: ParserState<any>;
 
 	constructor() {
@@ -312,11 +300,8 @@ class CommandState extends CompoundState<inputModule.CommandExpression> {
 		}
 	}
 
-	/**
-	 * @override
-	 */
 	parse(): StateStatus {
-		input.skipSpaces(true);
+		input.skipWhitespace(true);
 
 		if (this.parsingEnded()) {
 			this.handleEnd();
@@ -327,17 +312,11 @@ class CommandState extends CompoundState<inputModule.CommandExpression> {
 		return this.status;
 	}
 
-	/**
-	 * @override
-	 */
 	addExpression(expression: inputModule.Expression<any>): inputModule.Expression<any> {
 		this.expressions.push(expression);
 		return super.addExpression(expression);
 	}
 
-	/**
-	 * @override
-	 */
 	protected parsingEnded(): boolean {
 		return input.eof || input.current === ")";
 	}
@@ -360,12 +339,9 @@ class CommandState extends CompoundState<inputModule.CommandExpression> {
 	}
 }
 
-class CompoundParameterState<T extends inputModule.Parameter<any>> extends CompoundState<T> {
+class CompoundParameterState<T extends inputModule.Parameter> extends CompoundState<T> {
 	protected isWordsCollection: boolean;
 
-	/**
-	 * @override
-	 */
 	addExpression(expression: inputModule.Expression<any>): inputModule.Expression<any> {
 		if (expression instanceof inputModule.Word) {
 			this.isWordsCollection = true;
@@ -401,11 +377,8 @@ class ListState extends CompoundParameterState<inputModule.ListParameter> {
 		input.advance(true); // [
 	}
 
-	/**
-	 * @override
-	 */
 	parse(): StateStatus {
-		input.skipSpaces(true);
+		input.skipWhitespace(true);
 
 		if (this.parsingEnded()) {
 			let expressionState: inputModule.ExpressionState,
@@ -439,9 +412,6 @@ class ListState extends CompoundParameterState<inputModule.ListParameter> {
 		return this.status;
 	}
 
-	/**
-	 * @override
-	 */
 	addExpression(expression: inputModule.Expression<any>): inputModule.Expression<any> {
 		if (this.expecting !== "item" && this.expecting !== "item | end") {
 			input.throw("expression added in the wrong list state");
@@ -455,9 +425,6 @@ class ListState extends CompoundParameterState<inputModule.ListParameter> {
 		return expression;
 	}
 
-	/**
-	 * @override
-	 */
 	protected parsingEnded(): boolean {
 		return input.eof || (input.current === "]" && (this.expecting === "comma | end" || this.expecting === "item | end"));
 	}
@@ -476,11 +443,8 @@ class MapState extends CompoundParameterState<inputModule.MapParameter> {
 		input.advance(true); // {
 	}
 
-	/**
-	 * @override
-	 */
 	parse(): StateStatus {
-		input.skipSpaces(true);
+		input.skipWhitespace(true);
 
 		if (this.parsingEnded()) {
 			let expressionState: inputModule.ExpressionState,
@@ -524,9 +488,6 @@ class MapState extends CompoundParameterState<inputModule.MapParameter> {
 		return this.status;
 	}
 
-	/**
-	 * @override
-	 */
 	addExpression(expression: inputModule.Expression<any>): inputModule.Expression<any> {
 		expression = super.addExpression(expression);
 
@@ -544,12 +505,7 @@ class MapState extends CompoundParameterState<inputModule.MapParameter> {
 		return expression;
 	}
 
-	/**
-	 * @override
-	 */
 	protected parsingEnded(): boolean {
 		return input.eof || (input.current === "}" && (this.expecting === "key | end" || this.expecting === "comma | end"));
 	}
 }
-
-

--- a/scripts/src/app/input.ts
+++ b/scripts/src/app/input.ts
@@ -83,7 +83,7 @@ export class WordTransformer {
 	}
 }
 
-export class Expression<T> {
+export class Expression<T = any> {
 	private expressionRange: Range;
 	private expressionState: ExpressionState;
 	private expressionInput: string;
@@ -114,9 +114,9 @@ export class Expression<T> {
 	}
 }
 
-export class CommandExpression extends Expression<Expression<any>[]> {
-	public getExpressions(): Expression<any>[] {
-		return <Expression<any>[]> this.value;
+export class CommandExpression extends Expression<Expression[]> {
+	public getExpressions(): Expression[] {
+		return <Expression[]> this.value;
 	}
 }
 
@@ -142,10 +142,9 @@ export class Word extends Expression<string> implements WordTransformer {
 }
 utils.applyMixins(Word, [WordTransformer]);
 
-export class Keyword extends Expression<string> {
-}
+export class Keyword extends Expression<string> {}
 
-export class Parameter<T> extends Expression<T> implements collections.Hashable {
+export class Parameter<T = any> extends Expression<T> implements collections.Hashable {
 	/**
 	 * @override
 	 */
@@ -218,7 +217,7 @@ export abstract class CompoundParameter<Pt, Rt> extends Parameter<Pt> {
 	public abstract getParameterValues(): Rt;
 }
 
-export class ListParameter extends CompoundParameter<Parameter<any>[], any[]> {
+export class ListParameter extends CompoundParameter<Parameter[], any[]> {
 	public getParameterValues(): any[] {
 		return this.expressionValue.map(param => {
 			if (param instanceof CompoundParameter) {
@@ -250,7 +249,7 @@ export class WordsListParameter extends ListParameter {
 	}
 }
 
-export class MapParameter extends CompoundParameter<collections.EntryMap<Parameter<any>, Parameter<any>>, collections.FugaziMap<any>> {
+export class MapParameter extends CompoundParameter<collections.EntryMap<Parameter, Parameter>, collections.FugaziMap<any>> {
 	public getParameterValues(): collections.FugaziMap<any> {
 		const values = collections.map<any>();
 

--- a/scripts/src/app/terminal.ts
+++ b/scripts/src/app/terminal.ts
@@ -15,7 +15,6 @@ import * as types from "../components/types";
 import * as commands from "../components/commands";
 import * as handler from "../components/commands.handler";
 
-
 export interface Properties {
 	name: string;
 	title?: string;
@@ -85,8 +84,7 @@ export class TerminalContext extends BaseTerminalContext {
 	}
 }
 
-export class RestrictedTerminalContext extends BaseTerminalContext {
-}
+export class RestrictedTerminalContext extends BaseTerminalContext {}
 
 export class TerminalCommand extends commands.LocalCommand {
 	constructor() {

--- a/scripts/src/view/input/base.tsx
+++ b/scripts/src/view/input/base.tsx
@@ -343,6 +343,16 @@ export class TextInputView<P extends InputProperties, S extends InputState> exte
 
 		return Object.assign({}, super.getViewProperties(), { rows: Math.min(linesCount, 4) });
 	}
+
+	protected getLinesCount(): number {
+		// might end up being a naive implementation
+		return this.getValue().split("\n").length;
+	}
+
+	protected getCurrentLine(): number {
+		// might end up being a naive implementation
+		return this.getValue().substring(0, this.getPosition()).split("\n").length;
+	}
 }
 
 export interface SuggestibleInputProperties<T> extends InputProperties {

--- a/scripts/src/view/input/base.tsx
+++ b/scripts/src/view/input/base.tsx
@@ -21,7 +21,7 @@ export class PasswordInputView extends view.View<PasswordInputViewProperties, vi
 				<div className="container">
 					<div className="inputbox">
 						<input type="password" onKeyDown={ this.onKeyDown.bind(this) }
-							   ref={ input => this.input = input }/>
+							ref={ input => this.input = input }/>
 					</div>
 				</div>
 			</article>
@@ -49,16 +49,72 @@ export interface InputState extends view.ViewState {
 	value?: string;
 }
 
-export abstract class InputView<P extends InputProperties, S extends InputState> extends view.View<P, S> {
+export class KeyEnum {
+	public readonly code: number;
+	public readonly name: string;
+	public readonly ordinal: number;
+
+	protected constructor(code: number, name: string, ordinal: number) {
+		this.code = code;
+		this.name = name;
+		this.ordinal = ordinal;
+	}
+}
+
+export class ModifierKey extends KeyEnum {
+	private static COUNTER = 0;
+	private static VALUES: ModifierKey[] = [];
+
+	public static ALT = new ModifierKey(18, "Alt");
+	public static SHIFT = new ModifierKey(16, "Shift");
+	public static CONTROL = new ModifierKey(17, "Ctrl");
+
+	public readonly flag: number;
+
+	private constructor(code: number, name: string) {
+		super(code, name, ModifierKey.COUNTER++);
+		this.flag = 1 << this.ordinal;
+
+		ModifierKey.VALUES.push(this);
+	}
+
+	public static values() {
+		return this.VALUES;
+	}
+}
+
+export class SpecialKey extends KeyEnum {
+	private static COUNTER = 0;
+	private static VALUES: SpecialKey[] = [];
+
+	public static TAB = new SpecialKey(9, "Tab");
+	public static ENTER = new SpecialKey(13, "Enter");
+	public static DELETE = new SpecialKey(8, "Del");
+	public static ESCAPE = new SpecialKey(27, "Esc");
+
+	private constructor(code: number, name: string) {
+		super(code, name, SpecialKey.COUNTER++);
+
+		SpecialKey.VALUES.push(this);
+	}
+
+	public static values() {
+		return this.VALUES;
+	}
+}
+
+export abstract class InputView<
+		P extends InputProperties = InputProperties,
+		S extends InputState = InputState,
+		I extends HTMLInputElement | HTMLTextAreaElement = HTMLInputElement> extends view.View<P, S> {
 	private prompt: string;
 	private className: string[];
 	private keymap: Map<string, () => boolean>;
 
-	protected inputbox: HTMLInputElement;
+	protected inputbox: I;
 
 	public constructor(props: P, className: string, prompt?: string) {
 		super(props);
-
 
 		this.prompt = prompt;
 		this.className = ["input", className];
@@ -69,15 +125,16 @@ export abstract class InputView<P extends InputProperties, S extends InputState>
 	}
 
 	public componentDidMount(): void {
-		this.inputbox = ReactDOM.findDOMNode<HTMLInputElement>(this.refs["inputbox"] as React.ClassicComponent<any, any>);
 		this.inputbox.focus();
 		this.setCaretPosition(this.getValue().length);
 	}
 
 	public render(): JSX.Element {
-		return <article className={ this.className.join(" ") }>
-			{ this.getInnerElements() }
-		</article>;
+		return (
+			<article className={ this.className.join(" ") }>
+				{ this.getInnerElements() }
+			</article>
+		);
 	}
 
 	protected getPosition(): number {
@@ -107,61 +164,61 @@ export abstract class InputView<P extends InputProperties, S extends InputState>
 	}
 
 	protected getContainerElements(): JSX.Element[] {
+		const type = this.getInputType(),
+			props = this.getViewProperties();
+
 		return [
 			<div key="inputbox" className="inputbox">
-				<input tabIndex={ -1 } key="input" type="text" ref="inputbox" value={ this.state.value }
-					   onFocus={ this.onFocus.bind(this) }
-					   onBlur={ this.onBlur.bind(this) }
-					   onChange={ this.onChange.bind(this) }
-					   onCopy={ this.onCopy.bind(this) }
-					   onCut={ this.onCut.bind(this) }
-					   onPaste={ this.onPaste.bind(this) }
-					   onKeyUp={ this.onKeyUp.bind(this) }
-					   onKeyPress={ this.onKeyPress.bind(this) }
-					   onKeyDown={ this.onKeyDown.bind(this) }/>
-			</div>];
+				{ React.createElement(type, props) }
+			</div>
+		];
 	}
 
-	protected addKeyMapping(alt: boolean, ctrl: boolean, shift: boolean, char: string, fn: () => boolean): void {
-		let key = "";
+	protected getInputType(): "input" | "textarea" {
+		return "input";
+	}
 
-		if (alt) {
-			key += "A";
-		}
+	protected getViewProperties() {
+		return {
+			key: "input",
+			tabIndex: -1,
+			ref: (el: I | null) => {
+				this.inputbox = el;
+				if (this.inputbox) {
+					this.inputbox.focus();
+				}
+			},
+			value: this.state.value,
+			onCut: this.onCut.bind(this),
+			onBlur: this.onBlur.bind(this),
+			onCopy: this.onCopy.bind(this),
+			onFocus: this.onFocus.bind(this),
+			onPaste: this.onPaste.bind(this),
+			onKeyUp: this.onKeyUp.bind(this),
+			onChange: this.onChange.bind(this),
+			onKeyDown: this.onKeyDown.bind(this),
+			onKeyPress: this.onKeyPress.bind(this)
+		};
+	}
 
-		if (ctrl) {
-			key += "C";
-		}
-
-		if (shift) {
-			key += "S";
-		}
-
-		key += "+" + char.toUpperCase();
-		this.keymap.set(key, fn);
+	protected addKeyMapping(cb: () => boolean, char: string | SpecialKey, ...modifiers: ModifierKey[]): void {
+		this.keymap.set(createModifiersSequenceKey(char, ...modifiers), cb);
 	}
 
 	// React/DOM events
-	protected onFocus(event: React.FocusEventHandler<any>): void {
-	}
+	protected onFocus(event: React.FocusEventHandler<any>): void {}
 
-	protected onBlur(event: React.FocusEventHandler<any>): void {
-	}
+	protected onBlur(event: React.FocusEventHandler<any>): void {}
 
-	protected onCopy(event: React.ClipboardEventHandler<any>): void {
-	}
+	protected onCopy(event: React.ClipboardEventHandler<any>): void {}
 
-	protected onCut(event: React.ClipboardEventHandler<any>): void {
-	}
+	protected onCut(event: React.ClipboardEventHandler<any>): void {}
 
-	protected onPaste(event: React.ClipboardEventHandler<any>): void {
-	}
+	protected onPaste(event: React.ClipboardEventHandler<any>): void {}
 
-	protected onKeyUp(event: React.KeyboardEvent<any>): void {
-	}
+	protected onKeyUp(event: React.KeyboardEvent<any>): void {}
 
-	protected onKeyPress(event: React.KeyboardEvent<any>): void {
-	}
+	protected onKeyPress(event: React.KeyboardEvent<any>): void {}
 
 	protected onKeyDown(event: React.KeyboardEvent<any>): void {
 		let stopPropagation: boolean;
@@ -249,6 +306,22 @@ export abstract class InputView<P extends InputProperties, S extends InputState>
 	}
 }
 
+export class TextInputView<P extends InputProperties, S extends InputState> extends InputView<P, S, HTMLTextAreaElement> {
+	protected getInputType(): "input" | "textarea" {
+		return "textarea";
+	}
+
+	protected getViewProperties() {
+		let linesCount = 1;
+
+		if (this.state.value) {
+			linesCount += this.state.value.length - this.state.value.replace(/\n/g, "").length;
+		}
+
+		return Object.assign({}, super.getViewProperties(), { rows: Math.min(linesCount, 4) });
+	}
+}
+
 export interface SuggestibleInputProperties<T> extends InputProperties {
 	suggestions?: T[];
 }
@@ -269,7 +342,7 @@ export type ItemRendererMouseEventsHandler = {
 };
 export type ItemRenderer<T> = (item: T, index: number, handler: ItemRendererMouseEventsHandler, selected: boolean) => JSX.Element;
 
-export abstract class SuggestibleInputView<P extends SuggestibleInputProperties<T>, S extends SuggestibleInputState<T>, T> extends InputView<P, S> {
+export abstract class SuggestibleInputView<P extends SuggestibleInputProperties<T>, S extends SuggestibleInputState<T>, T> extends TextInputView<P, S> {
 	private suggestionPanel: SuggestionPanel;
 
 	public constructor(props: P, className: string, prompt?: string) {
@@ -477,9 +550,14 @@ export class BackgroundTextInput<P extends BackgroundTextInputProperties, S exte
 	}
 
 	protected getContainerElements(): JSX.Element[] {
-		let elements = super.getContainerElements();
-		elements.push(<div key="bgtextbox" className="bgtextbox"><BackgroundTextBox text={ this.state.backgroundText }/>
-		</div>);
+		const elements = super.getContainerElements();
+
+		elements.push(
+			<div key="bgtextbox" className="bgtextbox">
+				<BackgroundTextBox text={ this.state.backgroundText } />
+			</div>
+		);
+
 		return elements;
 	}
 }
@@ -498,22 +576,34 @@ class BackgroundTextBox extends view.View<BackgroundTextBoxProperties, view.View
 	}
 }
 
+function createModifiersSequenceKey(char: string | SpecialKey, ...specials: ModifierKey[]): string {
+	return createSequenceKey(char, specials.reduce<number>((flags, modifier) => flags | modifier.flag, 0));
+}
+
 function createEventSequenceKey(event: React.KeyboardEvent<any>): string {
-	let key = "";
+	let flags = 0;
 
 	if (event.altKey) {
-		key += "A";
+		flags |= ModifierKey.ALT.flag;
 	}
-
 	if (event.ctrlKey) {
-		key += "C";
+		flags |= ModifierKey.CONTROL.flag;
 	}
-
 	if (event.shiftKey) {
-		key += "S";
+		flags |= ModifierKey.SHIFT.flag;
 	}
 
-	key += "+" + String.fromCharCode(event.which).toUpperCase();
+	return createSequenceKey(event.key, flags);
+}
 
-	return key;
+function createSequenceKey(char: string | SpecialKey, flags: number) {
+	let key = "";
+
+	ModifierKey.values().forEach(modifier => {
+		if (flags & modifier.flag) {
+			key += modifier.name + "+";
+		}
+	});
+
+	return key + (typeof char === "string" ? char : char.name);
 }

--- a/scripts/src/view/input/fugaziInput.tsx
+++ b/scripts/src/view/input/fugaziInput.tsx
@@ -129,7 +129,9 @@ export class FugaziInputView extends base.SuggestibleInputView<FugaziInputProper
 	}
 
 	protected onEnterPressed(): boolean {
-		if (!this.inputbox.value.empty()) {
+		if (this.isCurrentlyInAString() || this.getValue()[this.getPosition() - 1] === "\\") {
+			this.setState({ value: this.getValue() + "\n" });
+		} else if (!this.inputbox.value.empty()) {
 			this.history.mark(this.getValue());
 			this.props.onExecute(this.inputbox.value);
 			this.inputbox.value = "";
@@ -198,6 +200,23 @@ export class FugaziInputView extends base.SuggestibleInputView<FugaziInputProper
 		this.history.update(this.getValue());
 		this.props.onSearchHistoryRequested();
 		return true;
+	}
+
+	private isCurrentlyInAString(): boolean {
+		const value = this.getValue();
+		let quotesType: string | null = null;
+
+		for (let i = 0; i < this.getPosition(); i++) {
+			if (value[i] === quotesType) {
+				quotesType = null;
+			} else if (quotesType !== null || value[i] === "\\") {
+				continue;
+			} else if (value[i] === "\"" || value[i] === "'") {
+				quotesType = value[i];
+			}
+		}
+
+		return quotesType !== null;
 	}
 }
 

--- a/scripts/src/view/input/fugaziInput.tsx
+++ b/scripts/src/view/input/fugaziInput.tsx
@@ -130,11 +130,12 @@ export class FugaziInputView extends base.SuggestibleInputView<FugaziInputProper
 
 	protected onEnterPressed(): boolean {
 		if (this.isCurrentlyInAString() || this.getValue()[this.getPosition() - 1] === "\\") {
-			this.setState({ value: this.getValue() + "\n" });
+			this.setState({
+				value: this.getValue().substring(0, this.getPosition()) + "\n" + this.getValue().substring(this.getPosition())
+			});
 		} else if (!this.inputbox.value.empty()) {
-			this.history.mark(this.getValue());
+			this.history.mark(this.inputbox.value);
 			this.props.onExecute(this.inputbox.value);
-			this.inputbox.value = "";
 			this.setState({
 				value: "",
 				showing: false,
@@ -207,9 +208,11 @@ export class FugaziInputView extends base.SuggestibleInputView<FugaziInputProper
 		let quotesType: string | null = null;
 
 		for (let i = 0; i < this.getPosition(); i++) {
-			if (value[i] === quotesType) {
+			if (value[i] === "\\") {
+				i++;
+			} else if (value[i] === quotesType) {
 				quotesType = null;
-			} else if (quotesType !== null || value[i] === "\\") {
+			} else if (quotesType !== null) {
 				continue;
 			} else if (value[i] === "\"" || value[i] === "'") {
 				quotesType = value[i];

--- a/style/input.css
+++ b/style/input.css
@@ -14,14 +14,24 @@ main#ui article.terminal section.inputs .input > .container {
 	background-color: #252526;
 }
 
-main#ui article.terminal section.inputs .input input {
+main#ui article.terminal section.inputs .input input,
+main#ui article.terminal section.inputs .input textarea {
 	outline: 0;
 	padding: 0;
 	width: 100%;
 	border: 0px;
-	font-size: 12px;
 	color: #ADADAD;
+	font-size: 12px;
 	background-color: transparent;
+}
+
+/*main#ui article.terminal section.inputs .input input {*/
+main#ui article.terminal section.inputs .input textarea {
+	resize: none;
+	white-space: pre;
+	overflow-x: hidden;
+	vertical-align: top;
+	overflow-wrap: normal;
 }
 
 main#ui article.terminal section.inputs .suggestible.input .suggestionPanel {


### PR DESCRIPTION
This is now working as described in the [issue](https://github.com/fugazi-io/webclient/issues/110), when pressing `enter` when within a string, otherwise when `\` or `shift+enter`.  
When in a "multiline mode" the up/down arrows behave as you'd expect, instead of changing the input based on the history, until you reach the top line (and press up) or the bottom line (and press down).

I also made some formatting changes and a few other irrelevant changes as I had to change some files I haven't had the chance to change for a while.

Notice that the only part that was changed was the input part, the output will still show the actual command and the result in single lines.
It shouldn't be hard to change the way the output reacts to line breaks, I'm just not sure what's the right (expected?) behavior.

Any thoughts?